### PR TITLE
Clear commander effects only for the starting player to preserve defensive buffs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1021,9 +1021,8 @@ function resetActionPointsForPlayer(playerId) {
   }
 }
 
-function clearCommanderEffects() {
-  state.commanderEffects[1] = {};
-  state.commanderEffects[2] = {};
+function clearCommanderEffectsForPlayer(playerId) {
+  state.commanderEffects[playerId] = {};
 }
 
 function endTurn() {
@@ -1042,7 +1041,7 @@ function endTurn() {
   state.currentPlayer = state.currentPlayer === 1 ? 2 : 1;
   if (state.currentPlayer === 1) state.turnNumber++;
 
-  clearCommanderEffects();
+  clearCommanderEffectsForPlayer(state.currentPlayer);
   resetActionPointsForPlayer(state.currentPlayer);
   updateVision();
   checkGameOver();


### PR DESCRIPTION
### Motivation
- Fix a high-priority bug where commander effects were wiped for both players at turn switch, removing defensive buffs before the opponent's attacks. 
- Ensure abilities like WALL's `ironSkinActive` remain active during the enemy's incoming attacks so defensive cooldowns function as intended. 
- Keep turn transition semantics: cooldowns tick down for the previous player while effects for the player who begins the new turn are reset. 

### Description
- Replace `clearCommanderEffects()` (which cleared effects for both players) with `clearCommanderEffectsForPlayer(playerId)` that clears effects only for a single player. 
- Update `endTurn()` to call `clearCommanderEffectsForPlayer(state.currentPlayer)` so only the player who is starting their turn has their command effects reset. 
- No other gameplay logic was changed, preserving existing cooldown and energy handling. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a79ebaac483298d3a1775d38f8684)